### PR TITLE
Fix Firebase config typo

### DIFF
--- a/lib/firebase.js
+++ b/lib/firebase.js
@@ -9,7 +9,7 @@ const firebaseConfig = {
   apiKey: "AIzaSyDbp5S3KgUyB4hFsJo1DNGNZE_OoywUccI",
   authDomain: "farm-2e0be.firebaseapp.com",
   projectId: "farm-2e0be",
-  storageBucket: "farm-2e0be.firebasestorage.app",
+  storageBucket: "farm-2e0be.appspot.com",
   messagingSenderId: "959621827551",
   appId: "1:959621827551:web:4f32c91b7d3609d8d0126a",
   measurementId: "G-X49LESK80M",


### PR DESCRIPTION
## Summary
- correct the Firebase storage bucket name

## Testing
- `npx tsc --noEmit` *(fails: `npm warn Unknown env config "http-proxy"` and `next` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6852dda6fd8c8333b61e53806209a17a